### PR TITLE
Show Base Name Instead of Path

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,7 @@
 var editor = document.getElementById("edit");
 var fileData = document.getElementById("file-data");
 const {ipcRenderer} = require("electron");
+var path = require("path");
 
 var savePreferences: SaveData = {
     saveName: "Unsaved Note",
@@ -80,7 +81,7 @@ function editorKeydown(event) {
 }
 
 function setUnsaved(): void {
-    fileData.innerHTML = `${savePreferences.saveName}*`;
+    fileData.innerHTML = `${path.basename(savePreferences.saveName)}*`;
 }
 
 interface ModalOptions {
@@ -130,7 +131,7 @@ ipcRenderer.on("fileData", (event, data: string, newFileData: string, filename: 
     (<HTMLInputElement>editor).value = data;
     fileData.innerHTML = newFileData;
     savePreferences.saveName = filename;
-    savePreferences.saveInfo = filename + " - Saved";
+    savePreferences.saveInfo = `${path.basename(filename)} - Saved`;
     fileData.innerHTML = savePreferences.saveInfo;
 });
 
@@ -138,7 +139,7 @@ ipcRenderer.on("fileData-alticatordoc", (event, data: string, newFileData: strin
     (<HTMLInputElement>editor).value = data;
     fileData.innerHTML = newFileData;
     savePreferences.saveName = filename;
-    savePreferences.saveInfo = filename + " - Saved";
+    savePreferences.saveInfo = `${path.basename(filename)} - Saved`;
     fileData.innerHTML = savePreferences.saveInfo;
     if (styleData.font != "") {
         editor.style.fontFamily = styleData.font;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 // Include
 const { app, BrowserWindow, Menu, MenuItem } = require('electron')
-const path = require("path");
+var path = require("path");
 
 var win;
 
@@ -168,7 +168,7 @@ function saveFile(editorContent: string, doSaveAs: boolean, saveName: string, st
     var sendData = {
       saveName: fileName,
       content: "",
-      saveInfo: `${fileName} - Saved`
+      saveInfo: `${path.basename(fileName)} - Saved`
     }
     win.webContents.send("fileInfo", sendData);
   }
@@ -199,7 +199,7 @@ function saveFile(editorContent: string, doSaveAs: boolean, saveName: string, st
       var sendData = {
         saveName: fileName,
         content: "",
-        saveInfo: `${fileName} - Saved`
+        saveInfo: `${path.basename(fileName)} - Saved`
       }
       win.webContents.send("fileInfo", sendData);
     }
@@ -216,7 +216,7 @@ function saveFile(editorContent: string, doSaveAs: boolean, saveName: string, st
       var sendData = {
         saveName: saveName,
         content: "",
-        saveInfo: `${saveName} - Saved`
+        saveInfo: `${path.basename(saveName)} - Saved`
       }
       win.webContents.send("fileInfo", sendData);
     }


### PR DESCRIPTION
Show the file base name instead of the file path on the toolbar.
Closes #28