### PR TITLE
Add File Info and Add Separators to File Menu (dev-39)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -2,6 +2,7 @@ var editor = document.getElementById("edit");
 var fileData = document.getElementById("file-data");
 const {ipcRenderer} = require("electron");
 var path = require("path");
+var fs = require("fs");
 
 var savePreferences: SaveData = {
     saveName: "Unsaved Note",
@@ -227,5 +228,41 @@ ipcRenderer.on("request", (event, data: string) => {
         case "exportHTML":
             commandExportHTML();
             break;
+        case "fileInfo":
+            if (!saveAs) {
+                document.getElementById("file-name").innerHTML = path.basename(savePreferences.saveName);
+                document.getElementById("file-path").innerHTML = savePreferences.saveName;
+                var fileFormat = path.extname(savePreferences.saveName);
+                var fileFormatName;
+                if (fileFormat == ".alticatordoc") {
+                    fileFormatName = "AlticatorDoc";
+                }
+                else if (fileFormat == ".txt") {
+                    fileFormatName = "Plain Text";
+                }
+                else {
+                    fileFormatName = `Other (${fileFormatName})`
+                }
+                document.getElementById("file-format").innerHTML = fileFormatName;
+                fs.stat(savePreferences.saveName, (err, data) => {
+                    if (err) throw err;
+                    if (data.size / 1000000 > 1) {
+                        document.getElementById("file-size").innerHTML = `${data.size / 1000000} MB`;
+                    }
+                    else if (data.size / 1000 > 1) {
+                        document.getElementById("file-size").innerHTML = `${data.size / 1000} KB`;
+                    }
+                    else {
+                        document.getElementById("file-size").innerHTML = `${data.size} B`;
+                    }
+                });
+            }
+            else {
+                document.getElementById("file-name").innerHTML = "Not Saved";
+                document.getElementById("file-path").innerHTML = "Not Saved";
+                document.getElementById("file-size").innerHTML = "Not Saved";
+                document.getElementById("file-format").innerHTML = "Not Saved";
+            }
+            document.getElementById("file-info").style.display = "initial";
     }
 })

--- a/src/index.html
+++ b/src/index.html
@@ -27,6 +27,28 @@
 				</div>
 			</div>
 		</div>
+		<div class="modal-container" id="file-info" style="display: none;">
+			<div class="modal">
+				<div class="modal-header">
+					File Info
+				</div>
+				<div class="modal-body">
+					<b>File Name: </b>
+					<span id="file-name"></span><br>
+					<b>File Path: </b>
+					<span id="file-path"></span><br>
+					<b>File Size: </b>
+					<span id="file-size"></span><br>
+					<b>File Format: </b>
+					<span id="file-format"></span><br>
+				</div>
+				<div class="modal-footer">
+					<button onclick="document.getElementById('file-info').style.display = 'none';">
+						OK
+					</button>
+				</div>
+			</div>
+		</div>
 		<nav>
 			<div id="controls">
 				<button onclick="askNew()">

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,11 @@ menu.append(new MenuItem({
       }
     },
     {
+      label: "Open",
+      accelerator: process.platform === "darwin" ? "Cmd+O" : "Ctrl+O",
+      click: () => openFile()
+    },
+    {
       label: "Save",
       accelerator: process.platform === "darwin" ? "Cmd+S" : "Ctrl+S",
       click: () => {
@@ -84,9 +89,7 @@ menu.append(new MenuItem({
       }
     },
     {
-      label: "Open",
-      accelerator: process.platform === "darwin" ? "Cmd+O" : "Ctrl+O",
-      click: () => openFile()
+      type: "separator"
     },
     {
       label: "Print",
@@ -99,6 +102,9 @@ menu.append(new MenuItem({
       click: () => {
         win.webContents.send("request", "exportHTML");
       }
+    },
+    {
+      type: "separator"
     },
     {
       label: "File Info",

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,6 +99,11 @@ menu.append(new MenuItem({
       click: () => {
         win.webContents.send("request", "exportHTML");
       }
+    },
+    {
+      label: "File Info",
+      accelerator: process.platform === "darwin" ? "Cmd+Shift+I" : "Ctrl+Shift+I",
+      click: () => win.webContents.send("request", "fileInfo")
     }
 ]
 }));
@@ -115,7 +120,7 @@ Menu.setApplicationMenu(menu);
 
 // Save and Open Files
 const {ipcMain} = require("electron");
-const fs = require("fs");
+var fs = require("fs");
 const {dialog} = require("electron");
 
 ipcMain.on("command", function(event, message: string, content?, saveAs?, saveName?, styleElem?: any): void {


### PR DESCRIPTION
1. Add file info (`File > File Info` or `Cmd+Shift+I` / `Ctrl+Shift+I`). Closes #39 
2. Add separators to the file menu to make it clearer. Closes #40 